### PR TITLE
Road objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(OpenDrive SHARED
     Road.cpp
     RoadMark.cpp
     RoadNetworkMesh.cpp
+    RoadObject.cpp
     Thirdparty/json11/json11.cpp
     Thirdparty/pugixml/pugixml.cpp
 )

--- a/CubicBezier.hpp
+++ b/CubicBezier.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <numeric>
 #include <set>
+#include <sstream>
 #include <stdio.h>
 
 namespace odr
@@ -110,7 +111,11 @@ template<typename T, size_t Dim>
 T CubicBezier<T, Dim>::get_t(T arclen) const
 {
     if ((arclen - this->length) > this->LengthTolerance || arclen < 0)
-        throw std::runtime_error("arclength out of range");
+    {
+        std::stringstream ss_err;
+        ss_err << "arclength " << arclen << " out of range; length: " << this->length;
+        throw std::runtime_error(ss_err.str());
+    }
 
     arclen = std::min<T>(arclen, this->length);
 

--- a/Lanes.cpp
+++ b/Lanes.cpp
@@ -54,7 +54,7 @@ Vec3D Lane::get_surface_pt(double s, double t, Vec3D* vn) const
         }
     }
 
-    return road_ptr->get_xyz(s, t, h_t, vn);
+    return road_ptr->get_xyz(s, t, h_t, nullptr, nullptr, vn);
 }
 
 std::set<double> Lane::approximate_border_linear(double s_start, double s_end, double eps, bool outer) const

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -7,7 +7,7 @@ namespace odr
 {
 void Mesh3D::add_mesh(const Mesh3D& other)
 {
-    CHECK((other.normals.empty() || other.normals.size() == other.vertices.size()), "nr. of normals does not match nr. of vertices");
+    // CHECK((other.normals.empty() || other.normals.size() == other.vertices.size()), "#normals != #vertices");
     const size_t idx_offset = this->vertices.size();
 
     this->vertices.insert(this->vertices.end(), other.vertices.begin(), other.vertices.end());
@@ -30,7 +30,7 @@ std::string Mesh3D::get_obj() const
         ss_obj << "vn " << vn[0] << ' ' << vn[1] << ' ' << vn[2] << std::endl;
     }
 
-    CHECK((this->normals.empty() || this->normals.size() == this->vertices.size()), "nr. of normals does not match nr. of vertices");
+    // CHECK((this->normals.empty() || this->normals.size() == this->vertices.size()), "#normals != #vertices");
 
     for (size_t idx = 0; idx < this->indices.size(); idx += 3)
     {

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -1,12 +1,13 @@
 #include "Mesh.h"
+#include "Utils.hpp"
 
 #include <sstream>
 
 namespace odr
 {
-
 void Mesh3D::add_mesh(const Mesh3D& other)
 {
+    CHECK((other.normals.empty() || other.normals.size() == other.vertices.size()), "nr. of normals does not match nr. of vertices");
     const size_t idx_offset = this->vertices.size();
 
     this->vertices.insert(this->vertices.end(), other.vertices.begin(), other.vertices.end());
@@ -28,12 +29,18 @@ std::string Mesh3D::get_obj() const
     {
         ss_obj << "vn " << vn[0] << ' ' << vn[1] << ' ' << vn[2] << std::endl;
     }
+
+    CHECK((this->normals.empty() || this->normals.size() == this->vertices.size()), "nr. of normals does not match nr. of vertices");
+
     for (size_t idx = 0; idx < this->indices.size(); idx += 3)
     {
         const size_t i1 = indices.at(idx) + 1;
         const size_t i2 = indices.at(idx + 1) + 1;
         const size_t i3 = indices.at(idx + 2) + 1;
-        ss_obj << "f " << i1 << "//" << i1 << ' ' << i2 << "//" << i2 << ' ' << i3 << "//" << i3 << std::endl;
+        if (this->normals.size() == this->vertices.size())
+            ss_obj << "f " << i1 << "//" << i1 << ' ' << i2 << "//" << i2 << ' ' << i3 << "//" << i3 << std::endl;
+        else
+            ss_obj << "f " << i1 << ' ' << i2 << ' ' << i3 << std::endl;
     }
 
     return ss_obj.str();

--- a/OpenDriveMap.cpp
+++ b/OpenDriveMap.cpp
@@ -467,14 +467,16 @@ Mesh3D OpenDriveMap::get_refline_lines(double eps) const
 
 RoadNetworkMesh OpenDriveMap::get_mesh(double eps) const
 {
-    RoadNetworkMesh out_mesh;
-    LanesMesh&      lanes_mesh = out_mesh.lanes_mesh;
-    RoadmarksMesh&  roadmarks_mesh = out_mesh.roadmarks_mesh;
+    RoadNetworkMesh  out_mesh;
+    LanesMesh&       lanes_mesh = out_mesh.lanes_mesh;
+    RoadmarksMesh&   roadmarks_mesh = out_mesh.roadmarks_mesh;
+    RoadObjectsMesh& road_objects_mesh = out_mesh.road_objects_mesh;
 
     for (std::shared_ptr<const Road> road : this->get_roads())
     {
         lanes_mesh.road_start_indices[lanes_mesh.vertices.size()] = road->id;
         roadmarks_mesh.road_start_indices[roadmarks_mesh.vertices.size()] = road->id;
+        road_objects_mesh.road_start_indices[road_objects_mesh.vertices.size()] = road->id;
 
         for (std::shared_ptr<const LaneSection> lanesec : road->get_lanesections())
         {
@@ -496,6 +498,13 @@ RoadNetworkMesh OpenDriveMap::get_mesh(double eps) const
                     roadmarks_mesh.add_mesh(lane->get_roadmark_mesh(roadmark, eps));
                 }
             }
+        }
+
+        for (std::shared_ptr<RoadObject> road_object : road->objects)
+        {
+            const size_t road_objs_idx_offset = road_objects_mesh.vertices.size();
+            road_objects_mesh.road_object_start_indices[road_objs_idx_offset] = road_object->id;
+            road_objects_mesh.add_mesh(road_object->get_mesh(eps));
         }
     }
 

--- a/OpenDriveMap.cpp
+++ b/OpenDriveMap.cpp
@@ -409,22 +409,16 @@ OpenDriveMap::OpenDriveMap(std::string xodr_file, bool with_lateralProfile, bool
                 road_object->repeats.push_back(std::move(road_object_repeat));
             }
 
-            for (pugi::xml_node corner_node : object_node.child("outline").children("cornerRoad"))
+            for (pugi::xml_node corner_node : object_node.child("outline").children("cornerLocal"))
             {
-                RoadObjectCorner road_object_corner;
-                road_object_corner.s = corner_node.attribute("s").as_double();
-                road_object_corner.t = corner_node.attribute("t").as_double();
-                road_object_corner.dz = corner_node.attribute("dz").as_double();
-                road_object_corner.height = corner_node.attribute("height").as_double();
+                RoadObjectCornerLocal road_object_corner_local;
+                road_object_corner_local.u = corner_node.attribute("u").as_double(0);
+                road_object_corner_local.v = corner_node.attribute("v").as_double(0);
+                road_object_corner_local.z = corner_node.attribute("z").as_double(0);
+                road_object_corner_local.height = corner_node.attribute("height").as_double(0);
 
-                CHECK_AND_REPAIR(road_object_corner.s >= 0, "cornerRoad::s < 0", road_object_corner.s = 0);
-
-                road_object->outline.push_back(std::move(road_object_corner));
+                road_object->local_outline.push_back(std::move(road_object_corner_local));
             }
-
-            /* check for cornerLocal outline - not implemented yet */
-            // if (object_node.child("outline").child("cornerLocal"))
-            //     printf("cornerLocal outline not supported\n");
 
             road->objects.push_back(road_object);
         }

--- a/OpenDriveMap.cpp
+++ b/OpenDriveMap.cpp
@@ -12,6 +12,7 @@
 #include "pugixml/pugixml.hpp"
 
 #include <iostream>
+#include <math.h>
 #include <string>
 #include <utility>
 
@@ -381,23 +382,29 @@ OpenDriveMap::OpenDriveMap(std::string xodr_file, bool with_lateralProfile, bool
             for (pugi::xml_node repeat_node : object_node.children("repeat"))
             {
                 RoadObjectRepeat road_object_repeat;
-                road_object_repeat.s0 = repeat_node.attribute("s").as_double();
-                road_object_repeat.length = repeat_node.attribute("length").as_double();
-                road_object_repeat.distance = repeat_node.attribute("distance").as_double();
-                road_object_repeat.t_start = repeat_node.attribute("tStart").as_double();
-                road_object_repeat.t_end = repeat_node.attribute("tEnd").as_double();
-                road_object_repeat.width_start = repeat_node.attribute("widthStart").as_double();
-                road_object_repeat.width_end = repeat_node.attribute("widthEnd").as_double();
-                road_object_repeat.height_start = repeat_node.attribute("heightStart").as_double();
-                road_object_repeat.height_end = repeat_node.attribute("heightEnd").as_double();
-                road_object_repeat.z_offset_start = repeat_node.attribute("zOffsetStart").as_double();
-                road_object_repeat.z_offset_end = repeat_node.attribute("zOffsetEnd").as_double();
+                road_object_repeat.s0 = repeat_node.attribute("s").as_double(NAN);
+                road_object_repeat.t_start = repeat_node.attribute("tStart").as_double(NAN);
+                road_object_repeat.t_end = repeat_node.attribute("tEnd").as_double(NAN);
+                road_object_repeat.width_start = repeat_node.attribute("widthStart").as_double(NAN);
+                road_object_repeat.width_end = repeat_node.attribute("widthEnd").as_double(NAN);
+                road_object_repeat.height_start = repeat_node.attribute("heightStart").as_double(NAN);
+                road_object_repeat.height_end = repeat_node.attribute("heightEnd").as_double(NAN);
+                road_object_repeat.z_offset_start = repeat_node.attribute("zOffsetStart").as_double(NAN);
+                road_object_repeat.z_offset_end = repeat_node.attribute("zOffsetEnd").as_double(NAN);
 
-                CHECK_AND_REPAIR(road_object_repeat.s0 >= 0, "repeat::s < 0", road_object_repeat.s0 = 0);
+                CHECK_AND_REPAIR(isnan(road_object_repeat.s0) || road_object_repeat.s0 >= 0, "repeat::s < 0", road_object_repeat.s0 = 0);
+                CHECK_AND_REPAIR(isnan(road_object_repeat.width_start) || road_object_repeat.width_start >= 0,
+                                 "repeat::widthStart < 0",
+                                 road_object_repeat.width_start = 0);
+                CHECK_AND_REPAIR(isnan(road_object_repeat.width_end) || road_object_repeat.width_end >= 0,
+                                 "repeat::widthStart < 0",
+                                 road_object_repeat.width_end = 0);
+
+                road_object_repeat.length = repeat_node.attribute("length").as_double(0);
+                road_object_repeat.distance = repeat_node.attribute("distance").as_double(0);
+
                 CHECK_AND_REPAIR(road_object_repeat.length >= 0, "repeat::length < 0", road_object_repeat.length = 0);
                 CHECK_AND_REPAIR(road_object_repeat.distance >= 0, "repeat::distance < 0", road_object_repeat.distance = 0);
-                CHECK_AND_REPAIR(road_object_repeat.width_start >= 0, "repeat::widthStart < 0", road_object_repeat.width_start = 0);
-                CHECK_AND_REPAIR(road_object_repeat.width_end >= 0, "repeat::widthStart < 0", road_object_repeat.width_end = 0);
 
                 road_object->repeats.push_back(std::move(road_object_repeat));
             }

--- a/OpenDriveMap.cpp
+++ b/OpenDriveMap.cpp
@@ -356,22 +356,22 @@ OpenDriveMap::OpenDriveMap(std::string xodr_file, bool with_lateralProfile, bool
             std::shared_ptr<RoadObject> road_object = std::make_shared<RoadObject>();
             road_object->road = road;
 
-            road_object->type = object_node.attribute("type").as_string();
-            road_object->name = object_node.attribute("name").as_string();
-            road_object->id = object_node.attribute("id").as_string();
-            road_object->orientation = object_node.attribute("orientation").as_string();
+            road_object->type = object_node.attribute("type").as_string("");
+            road_object->name = object_node.attribute("name").as_string("");
+            road_object->id = object_node.attribute("id").as_string("");
+            road_object->orientation = object_node.attribute("orientation").as_string("");
 
-            road_object->s0 = object_node.attribute("s").as_double();
-            road_object->t0 = object_node.attribute("t").as_double();
-            road_object->z0 = object_node.attribute("zOffset").as_double();
-            road_object->valid_length = object_node.attribute("validLength").as_double();
-            road_object->length = object_node.attribute("length").as_double();
-            road_object->width = object_node.attribute("width").as_double();
-            road_object->radius = object_node.attribute("radius").as_double();
-            road_object->height = object_node.attribute("height").as_double();
-            road_object->hdg = object_node.attribute("hdg").as_double();
-            road_object->pitch = object_node.attribute("pitch").as_double();
-            road_object->roll = object_node.attribute("roll").as_double();
+            road_object->s0 = object_node.attribute("s").as_double(0);
+            road_object->t0 = object_node.attribute("t").as_double(0);
+            road_object->z0 = object_node.attribute("zOffset").as_double(0);
+            road_object->valid_length = object_node.attribute("validLength").as_double(0);
+            road_object->length = object_node.attribute("length").as_double(0);
+            road_object->width = object_node.attribute("width").as_double(0);
+            road_object->radius = object_node.attribute("radius").as_double(0);
+            road_object->height = object_node.attribute("height").as_double(0);
+            road_object->hdg = object_node.attribute("hdg").as_double(0);
+            road_object->pitch = object_node.attribute("pitch").as_double(0);
+            road_object->roll = object_node.attribute("roll").as_double(0);
 
             CHECK_AND_REPAIR(road_object->s0 >= 0, "object::s < 0", road_object->s0 = 0);
             CHECK_AND_REPAIR(road_object->valid_length >= 0, "object::validLength < 0", road_object->valid_length = 0);

--- a/Road.cpp
+++ b/Road.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<LaneSection> Road::get_lanesection(double s)
     return lanesection;
 }
 
-Vec3D Road::get_xyz(double s, double t, double h, Vec3D* vn) const
+Vec3D Road::get_xyz(double s, double t, double h, Vec3D* _e_s, Vec3D* _e_t, Vec3D* _e_h) const
 {
     const Vec3D  s_vec = this->ref_line->get_grad(s);
     const double theta = this->superelevation.get(s);
@@ -86,8 +86,13 @@ Vec3D Road::get_xyz(double s, double t, double h, Vec3D* vn) const
 
     const Vec3D xyz = MatVecMultiplication(trans_mat, Vec3D{t, h, 1});
 
-    if (vn)
-        *vn = e_h;
+    if (_e_s)
+        *_e_s = e_s;
+    if (_e_t)
+        *_e_t = e_t;
+    if (_e_h)
+        *_e_h = e_h;
+
     return xyz;
 }
 

--- a/Road.h
+++ b/Road.h
@@ -4,11 +4,13 @@
 #include "LaneSection.h"
 #include "Lanes.h"
 #include "Math.hpp"
+#include "RoadObject.h"
 #include "Utils.hpp"
 
 #include <map>
 #include <memory>
 #include <set>
+#include <vector>
 
 namespace odr
 {
@@ -80,6 +82,8 @@ public:
     std::map<double, std::shared_ptr<LaneSection>> s_to_lanesection;
     std::map<double, std::string>                  s_to_type;
     std::map<double, SpeedRecord>                  s_to_speed;
+
+    std::vector<std::shared_ptr<RoadObject>> objects;
 };
 
 using ConstRoadSet = std::set<std::shared_ptr<const Road>, SharedPtrCmp<const Road, std::string, &Road::id>>;

--- a/Road.h
+++ b/Road.h
@@ -61,7 +61,7 @@ public:
     std::shared_ptr<const LaneSection> get_lanesection(double s) const;
     std::shared_ptr<LaneSection>       get_lanesection(double s);
 
-    Vec3D get_xyz(double s, double t, double h, Vec3D* vn = nullptr) const;
+    Vec3D get_xyz(double s, double t, double h, Vec3D* e_s = nullptr, Vec3D* e_t = nullptr, Vec3D* e_h = nullptr) const;
 
     double      length = 0;
     std::string id;

--- a/RoadNetworkMesh.cpp
+++ b/RoadNetworkMesh.cpp
@@ -74,6 +74,7 @@ Mesh3D RoadNetworkMesh::get_mesh() const
     Mesh3D out_mesh;
     out_mesh.add_mesh(this->lanes_mesh);
     out_mesh.add_mesh(this->roadmarks_mesh);
+    out_mesh.add_mesh(this->road_objects_mesh);
     return out_mesh;
 }
 

--- a/RoadNetworkMesh.h
+++ b/RoadNetworkMesh.h
@@ -50,12 +50,18 @@ struct RoadmarksMesh : public LanesMesh
     std::map<size_t, std::string> roadmark_type_start_indices;
 };
 
+struct RoadObjectsMesh : public RoadsMesh
+{
+    std::map<size_t, std::string> road_object_start_indices;
+};
+
 struct RoadNetworkMesh
 {
     Mesh3D get_mesh() const;
 
-    LanesMesh     lanes_mesh;
-    RoadmarksMesh roadmarks_mesh;
+    LanesMesh       lanes_mesh;
+    RoadmarksMesh   roadmarks_mesh;
+    RoadObjectsMesh road_objects_mesh;
 };
 
 } // namespace odr

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -86,7 +86,7 @@ Mesh3D RoadObject::get_mesh(double eps) const
     for (const RoadObjectRepeat& repeat : repeats_copy)
     {
         const double s_start = isnan(repeat.s0) ? this->s0 : repeat.s0;
-        const double s_end = s_start + std::min(repeat.length, road_ptr->length);
+        const double s_end = std::min(s_start + repeat.length, road_ptr->length);
 
         if (repeat.distance != 0)
         {

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -71,15 +71,14 @@ Mesh3D RoadObject::get_mesh(double eps) const
     Mesh3D road_obj_mesh;
     for (const RoadObjectRepeat& repeat : repeats_copy)
     {
-        const double obj_len = repeat.length > 0 ? repeat.length : this->length;
         const double s_start = isnan(repeat.s0) ? this->s0 : repeat.s0;
-        const double s_end = s_start + std::min(obj_len, road_ptr->length); // avoid division by zero
+        const double s_end = s_start + std::max(repeat.length, 1e-12); // avoid division by zero
 
         if (repeat.distance != 0)
         {
-            for (double s = s_start; s <= s_end; s += repeat.distance)
+            for (double s = s_start; (s - s_end) < 1e-9 && s < road_ptr->length; s += repeat.distance)
             {
-                const double progress = (s_start == s_end) ? 1.0 : (s - s_start) / (s_end - s_start);
+                const double progress = (s - s_start) / (s_end - s_start);
                 const double t_s =
                     (isnan(repeat.t_start) || isnan(repeat.t_end)) ? this->t0 : repeat.t_start + progress * (repeat.t_end - repeat.t_start);
                 const double z_s = (isnan(repeat.z_offset_start) || isnan(repeat.z_offset_end))

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -76,7 +76,7 @@ Mesh3D RoadObject::get_mesh(double eps) const
 
         if (repeat.distance != 0)
         {
-            for (double s = s_start; s < s_end; s += repeat.distance)
+            for (double s = s_start; s <= s_end; s += repeat.distance)
             {
                 const double progress = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
                 const double t_s =
@@ -101,12 +101,14 @@ Mesh3D RoadObject::get_mesh(double eps) const
                     single_road_obj_mesh = this->get_box(width_s, this->length, height_s);
                 }
 
-                /* apply rotation and transform s/t/h -> x/y/z */
+                Vec3D       e_s, e_t, e_h;
+                const Vec3D p0 = road_ptr->get_xyz(s, t_s, z_s, &e_s, &e_t, &e_h);
+                const Mat3D base_mat{{{e_s[0], e_t[0], e_h[0]}, {e_s[1], e_t[1], e_h[1]}, {e_s[2], e_t[2], e_h[2]}}};
                 for (Vec3D& pt_uvz : single_road_obj_mesh.vertices)
                 {
                     pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
-                    pt_uvz = add(pt_uvz, {s, t_s, z_s});
-                    pt_uvz = road_ptr->get_xyz(std::max<double>(std::min(pt_uvz[0], road_ptr->length), 0), pt_uvz[1], pt_uvz[2]);
+                    pt_uvz = MatVecMultiplication(base_mat, pt_uvz);
+                    pt_uvz = add(pt_uvz, p0);
                 }
 
                 road_obj_mesh.add_mesh(single_road_obj_mesh);

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -64,7 +64,7 @@ Mesh3D RoadObject::get_mesh(double eps) const
 
     std::vector<RoadObjectRepeat> repeats_copy = this->repeats;
     if (repeats_copy.empty())
-        repeats_copy.push_back({s0, 0, 1, t0, t0, width, width, height, height, z0, z0});
+        repeats_copy.push_back({NAN, 0, 1, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN});
 
     const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
 
@@ -96,11 +96,9 @@ Mesh3D RoadObject::get_mesh(double eps) const
                 {
                     single_road_obj_mesh = this->get_cylinder(eps, this->radius, height_s);
                 }
-                else if ((this->width > 0 || width_s > 0) && (this->length > 0))
+                else if (width_s > 0 && this->length > 0)
                 {
-                    const double w = (width_s > 0) ? width_s : this->width;
-                    const double h = (height_s > 0) ? height_s : this->height;
-                    single_road_obj_mesh = this->get_box(w, this->length, h);
+                    single_road_obj_mesh = this->get_box(width_s, this->length, height_s);
                 }
 
                 /* apply rotation and transform s/t/h -> x/y/z */

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -5,69 +5,110 @@
 
 namespace odr
 {
+Mesh3D RoadObject::get_cylinder(double eps, double radius, double height)
+{
+    Mesh3D cylinder_mesh;
+    cylinder_mesh.vertices.push_back({0, 0, 0});
+    cylinder_mesh.vertices.push_back({0, 0, height});
+
+    eps = 0.5 * eps; // reduce eps a bit, cylinders more subsceptible to low resolution
+    const double eps_angle = (radius <= eps) ? M_PI / 6 : std::acos((radius * radius - 4 * radius * eps + 2 * eps * eps) / (radius * radius));
+
+    std::vector<double> angles;
+    for (double alpha = 0; alpha < 2 * M_PI; alpha += eps_angle)
+        angles.push_back(alpha);
+    angles.push_back(2 * M_PI);
+
+    for (const double& alpha : angles)
+    {
+        const Vec3D circle_pt_bottom = {radius * std::cos(alpha), radius * std::sin(alpha), 0};
+        const Vec3D circle_pt_top = {radius * std::cos(alpha), radius * std::sin(alpha), height};
+        cylinder_mesh.vertices.push_back(circle_pt_bottom);
+        cylinder_mesh.vertices.push_back(circle_pt_top);
+
+        if (cylinder_mesh.vertices.size() > 5)
+        {
+            const size_t          cur_idx = cylinder_mesh.vertices.size() - 1;
+            std::array<size_t, 6> top_bottom_idx_patch = {0, cur_idx - 1, cur_idx - 3, 1, cur_idx - 2, cur_idx};
+            cylinder_mesh.indices.insert(cylinder_mesh.indices.end(), top_bottom_idx_patch.begin(), top_bottom_idx_patch.end());
+            std::array<size_t, 6> wall_idx_patch = {cur_idx, cur_idx - 2, cur_idx - 3, cur_idx, cur_idx - 3, cur_idx - 1};
+            cylinder_mesh.indices.insert(cylinder_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
+        }
+    }
+
+    return cylinder_mesh;
+}
+
+Mesh3D RoadObject::get_box(double w, double l, double h)
+{
+    Mesh3D box_mesh;
+    box_mesh.vertices = {Vec3D{l / 2, w / 2, 0},
+                         Vec3D{-l / 2, w / 2, 0},
+                         Vec3D{-l / 2, -w / 2, 0},
+                         Vec3D{l / 2, -w / 2, 0},
+                         Vec3D{l / 2, w / 2, h},
+                         Vec3D{-l / 2, w / 2, h},
+                         Vec3D{-l / 2, -w / 2, h},
+                         Vec3D{l / 2, -w / 2, h}};
+    box_mesh.indices = {0, 3, 1, 3, 2, 1, 4, 5, 7, 7, 5, 6, 7, 6, 3, 3, 6, 2, 5, 4, 1, 1, 4, 0, 0, 4, 7, 7, 3, 0, 1, 6, 5, 1, 2, 6};
+
+    return box_mesh;
+}
+
 Mesh3D RoadObject::get_mesh(double eps) const
 {
     auto road_ptr = this->road.lock();
     if (!road_ptr)
         throw std::runtime_error("could not access parent road for road object");
 
-    /* construct object in local coord system */
-    Mesh3D road_obj_mesh;
-    if (this->radius > 0)
-    {
-        /* cylinder */
-        road_obj_mesh.vertices.push_back({0, 0, 0});
-        road_obj_mesh.vertices.push_back({0, 0, this->height});
-
-        eps = 0.5 * eps; // reduce eps a bit, cylinders more subsceptible to low resolution
-        const double eps_angle = (radius <= eps) ? M_PI / 6 : std::acos((radius * radius - 4 * radius * eps + 2 * eps * eps) / (radius * radius));
-
-        std::vector<double> angles;
-        for (double alpha = 0; alpha < 2 * M_PI; alpha += eps_angle)
-            angles.push_back(alpha);
-        angles.push_back(2 * M_PI);
-
-        for (const double& alpha : angles)
-        {
-            const Vec3D circle_pt_bottom = {radius * std::cos(alpha), radius * std::sin(alpha), 0};
-            const Vec3D circle_pt_top = {radius * std::cos(alpha), radius * std::sin(alpha), this->height};
-            road_obj_mesh.vertices.push_back(circle_pt_bottom);
-            road_obj_mesh.vertices.push_back(circle_pt_top);
-
-            if (road_obj_mesh.vertices.size() > 5)
-            {
-                const size_t          cur_idx = road_obj_mesh.vertices.size() - 1;
-                std::array<size_t, 6> top_bottom_idx_patch = {0, cur_idx - 1, cur_idx - 3, 1, cur_idx - 2, cur_idx};
-                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), top_bottom_idx_patch.begin(), top_bottom_idx_patch.end());
-                std::array<size_t, 6> wall_idx_patch = {cur_idx, cur_idx - 2, cur_idx - 3, cur_idx, cur_idx - 3, cur_idx - 1};
-                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
-            }
-        }
-    }
-    else if (this->width > 0 && this->length > 0)
-    {
-        /* box */
-        const double& w = this->width;
-        const double& l = this->length;
-        const double& h = this->height;
-
-        road_obj_mesh.vertices = {Vec3D{l / 2, w / 2, 0},
-                                  Vec3D{-l / 2, w / 2, 0},
-                                  Vec3D{-l / 2, -w / 2, 0},
-                                  Vec3D{l / 2, -w / 2, 0},
-                                  Vec3D{l / 2, w / 2, h},
-                                  Vec3D{-l / 2, w / 2, h},
-                                  Vec3D{-l / 2, -w / 2, h},
-                                  Vec3D{l / 2, -w / 2, h}};
-        road_obj_mesh.indices = {0, 3, 1, 3, 2, 1, 4, 5, 7, 7, 5, 6, 7, 6, 3, 3, 6, 2, 5, 4, 1, 1, 4, 0, 0, 4, 7, 7, 3, 0, 1, 6, 5, 1, 2, 6};
-    }
+    std::vector<RoadObjectRepeat> repeats_copy = this->repeats;
+    if (repeats_copy.empty())
+        repeats_copy.push_back({s0, 0, 1, t0, t0, width, width, height, height, z0, z0});
 
     const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
-    for (Vec3D& pt_uvz : road_obj_mesh.vertices)
+
+    Mesh3D road_obj_mesh;
+    for (const RoadObjectRepeat& repeat : repeats_copy)
     {
-        pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
-        pt_uvz = add(pt_uvz, {this->s0, this->t0, this->z0});
-        pt_uvz = road_ptr->get_xyz(pt_uvz[0], pt_uvz[1], pt_uvz[2]);
+        const double s_start = repeat.s0;
+        const double s_end = repeat.s0 + std::max(repeat.length, 1e-12); // avoid division by zero
+
+        if (repeat.distance != 0)
+        {
+            for (double s = s_start; (s - s_end) < 1e-9 && s < road_ptr->length; s += repeat.distance)
+            {
+                const double progress = (s - s_start) / (s_end - s_start);
+                const double t_s = repeat.t_start + progress * (repeat.t_end - repeat.t_start);
+                const double z_s = repeat.z_offset_start + progress * (repeat.z_offset_end - repeat.z_offset_start);
+                const double height_s = repeat.height_start + progress * (repeat.height_end - repeat.height_start);
+                const double width_s = repeat.width_start + progress * (repeat.width_end - repeat.width_start);
+
+                Mesh3D single_road_obj_mesh;
+                if (this->radius > 0)
+                {
+                    single_road_obj_mesh = this->get_cylinder(eps, this->radius, height_s);
+                }
+                else if ((this->width > 0 || width_s > 0) && (this->length > 0))
+                {
+                    const double w = (width_s > 0) ? width_s : this->width;
+                    const double h = (height_s > 0) ? height_s : this->height;
+                    single_road_obj_mesh = this->get_box(w, this->length, h);
+                }
+
+                /* apply rotation and transform s/t/h -> x/y/z */
+                for (Vec3D& pt_uvz : single_road_obj_mesh.vertices)
+                {
+                    pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
+                    pt_uvz = add(pt_uvz, {s, t_s, z_s});
+                    pt_uvz = road_ptr->get_xyz(std::min(pt_uvz[0], road_ptr->length), pt_uvz[1], pt_uvz[2]);
+                }
+
+                road_obj_mesh.add_mesh(single_road_obj_mesh);
+
+                if (repeat.distance < 0)
+                    break;
+            }
+        }
     }
 
     return road_obj_mesh;

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -1,0 +1,43 @@
+#include "RoadObject.h"
+#include "Road.h"
+
+#include <math.h>
+
+namespace odr
+{
+Mesh3D RoadObject::get_mesh(double eps) const
+{
+    auto road_ptr = this->road.lock();
+    if (!road_ptr)
+        throw std::runtime_error("could not access parent road for road object");
+
+    Vec3D       e_s, e_t, e_h;
+    const Vec3D p0 = road_ptr->get_xyz(this->s0, this->t0, this->z0, &e_s, &e_t, &e_h);
+
+    const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
+    const Vec3D e_u = MatVecMultiplication(rot_mat, e_s);
+    const Vec3D e_v = MatVecMultiplication(rot_mat, e_t);
+    const Vec3D e_z = MatVecMultiplication(rot_mat, e_h);
+
+    Mesh3D road_obj_mesh;
+
+    if (radius > 0)
+    {
+        road_obj_mesh.vertices.push_back(p0);
+        const double eps_angle = std::acos((radius * radius - 4 * radius * eps + 2 * eps * eps) / (radius * radius));
+        for (double alpha = 0; alpha < 2 * M_PI; alpha += eps_angle)
+        {
+            const Vec3D circle_pt = {p0[0] + radius * std::cos(alpha), p0[1] + radius * std::sin(alpha), p0[2]};
+            road_obj_mesh.vertices.push_back(circle_pt);
+            if (road_obj_mesh.vertices.size() > 2)
+            {
+                const size_t          cur_idx = road_obj_mesh.vertices.size() - 1;
+                std::array<size_t, 3> idx_patch = {0, cur_idx - 1, cur_idx};
+                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), idx_patch.begin(), idx_patch.end());
+            }
+        }
+    }
+
+    return road_obj_mesh;
+}
+} // namespace odr

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -72,13 +72,13 @@ Mesh3D RoadObject::get_mesh(double eps) const
     for (const RoadObjectRepeat& repeat : repeats_copy)
     {
         const double s_start = isnan(repeat.s0) ? this->s0 : repeat.s0;
-        const double s_end = s_start + std::max(repeat.length, 1e-12); // avoid division by zero
+        const double s_end = s_start + std::min(repeat.length, road_ptr->length);
 
         if (repeat.distance != 0)
         {
-            for (double s = s_start; (s - s_end) < 1e-9 && s < road_ptr->length; s += repeat.distance)
+            for (double s = s_start; s < s_end; s += repeat.distance)
             {
-                const double progress = (s - s_start) / (s_end - s_start);
+                const double progress = (s_end == s_start) ? 1.0 : (s - s_start) / (s_end - s_start);
                 const double t_s =
                     (isnan(repeat.t_start) || isnan(repeat.t_end)) ? this->t0 : repeat.t_start + progress * (repeat.t_end - repeat.t_start);
                 const double z_s = (isnan(repeat.z_offset_start) || isnan(repeat.z_offset_end))

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -71,14 +71,15 @@ Mesh3D RoadObject::get_mesh(double eps) const
     Mesh3D road_obj_mesh;
     for (const RoadObjectRepeat& repeat : repeats_copy)
     {
+        const double obj_len = repeat.length > 0 ? repeat.length : this->length;
         const double s_start = isnan(repeat.s0) ? this->s0 : repeat.s0;
-        const double s_end = s_start + std::max(repeat.length, 1e-12); // avoid division by zero
+        const double s_end = s_start + std::min(obj_len, road_ptr->length); // avoid division by zero
 
         if (repeat.distance != 0)
         {
-            for (double s = s_start; (s - s_end) < 1e-9 && s < road_ptr->length; s += repeat.distance)
+            for (double s = s_start; s <= s_end; s += repeat.distance)
             {
-                const double progress = (s - s_start) / (s_end - s_start);
+                const double progress = (s_start == s_end) ? 1.0 : (s - s_start) / (s_end - s_start);
                 const double t_s =
                     (isnan(repeat.t_start) || isnan(repeat.t_end)) ? this->t0 : repeat.t_start + progress * (repeat.t_end - repeat.t_start);
                 const double z_s = (isnan(repeat.z_offset_start) || isnan(repeat.z_offset_end))

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -106,7 +106,7 @@ Mesh3D RoadObject::get_mesh(double eps) const
                 {
                     pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
                     pt_uvz = add(pt_uvz, {s, t_s, z_s});
-                    pt_uvz = road_ptr->get_xyz(std::min(pt_uvz[0], road_ptr->length), pt_uvz[1], pt_uvz[2]);
+                    pt_uvz = road_ptr->get_xyz(std::max<double>(std::min(pt_uvz[0], road_ptr->length), 0), pt_uvz[1], pt_uvz[2]);
                 }
 
                 road_obj_mesh.add_mesh(single_road_obj_mesh);

--- a/RoadObject.cpp
+++ b/RoadObject.cpp
@@ -11,31 +11,63 @@ Mesh3D RoadObject::get_mesh(double eps) const
     if (!road_ptr)
         throw std::runtime_error("could not access parent road for road object");
 
-    Vec3D       e_s, e_t, e_h;
-    const Vec3D p0 = road_ptr->get_xyz(this->s0, this->t0, this->z0, &e_s, &e_t, &e_h);
-
-    const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
-    const Vec3D e_u = MatVecMultiplication(rot_mat, e_s);
-    const Vec3D e_v = MatVecMultiplication(rot_mat, e_t);
-    const Vec3D e_z = MatVecMultiplication(rot_mat, e_h);
-
+    /* construct object in local coord system */
     Mesh3D road_obj_mesh;
-
-    if (radius > 0)
+    if (this->radius > 0)
     {
-        road_obj_mesh.vertices.push_back(p0);
-        const double eps_angle = std::acos((radius * radius - 4 * radius * eps + 2 * eps * eps) / (radius * radius));
+        /* cylinder */
+        road_obj_mesh.vertices.push_back({0, 0, 0});
+        road_obj_mesh.vertices.push_back({0, 0, this->height});
+
+        eps = 0.5 * eps; // reduce eps a bit, cylinders more subsceptible to low resolution
+        const double eps_angle = (radius <= eps) ? M_PI / 6 : std::acos((radius * radius - 4 * radius * eps + 2 * eps * eps) / (radius * radius));
+
+        std::vector<double> angles;
         for (double alpha = 0; alpha < 2 * M_PI; alpha += eps_angle)
+            angles.push_back(alpha);
+        angles.push_back(2 * M_PI);
+
+        for (const double& alpha : angles)
         {
-            const Vec3D circle_pt = {p0[0] + radius * std::cos(alpha), p0[1] + radius * std::sin(alpha), p0[2]};
-            road_obj_mesh.vertices.push_back(circle_pt);
-            if (road_obj_mesh.vertices.size() > 2)
+            const Vec3D circle_pt_bottom = {radius * std::cos(alpha), radius * std::sin(alpha), 0};
+            const Vec3D circle_pt_top = {radius * std::cos(alpha), radius * std::sin(alpha), this->height};
+            road_obj_mesh.vertices.push_back(circle_pt_bottom);
+            road_obj_mesh.vertices.push_back(circle_pt_top);
+
+            if (road_obj_mesh.vertices.size() > 5)
             {
                 const size_t          cur_idx = road_obj_mesh.vertices.size() - 1;
-                std::array<size_t, 3> idx_patch = {0, cur_idx - 1, cur_idx};
-                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), idx_patch.begin(), idx_patch.end());
+                std::array<size_t, 6> top_bottom_idx_patch = {0, cur_idx - 1, cur_idx - 3, 1, cur_idx - 2, cur_idx};
+                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), top_bottom_idx_patch.begin(), top_bottom_idx_patch.end());
+                std::array<size_t, 6> wall_idx_patch = {cur_idx, cur_idx - 2, cur_idx - 3, cur_idx, cur_idx - 3, cur_idx - 1};
+                road_obj_mesh.indices.insert(road_obj_mesh.indices.end(), wall_idx_patch.begin(), wall_idx_patch.end());
             }
         }
+    }
+    else if (this->width > 0 && this->length > 0)
+    {
+        /* box */
+        const double& w = this->width;
+        const double& l = this->length;
+        const double& h = this->height;
+
+        road_obj_mesh.vertices = {Vec3D{l / 2, w / 2, 0},
+                                  Vec3D{-l / 2, w / 2, 0},
+                                  Vec3D{-l / 2, -w / 2, 0},
+                                  Vec3D{l / 2, -w / 2, 0},
+                                  Vec3D{l / 2, w / 2, h},
+                                  Vec3D{-l / 2, w / 2, h},
+                                  Vec3D{-l / 2, -w / 2, h},
+                                  Vec3D{l / 2, -w / 2, h}};
+        road_obj_mesh.indices = {0, 3, 1, 3, 2, 1, 4, 5, 7, 7, 5, 6, 7, 6, 3, 3, 6, 2, 5, 4, 1, 1, 4, 0, 0, 4, 7, 7, 3, 0, 1, 6, 5, 1, 2, 6};
+    }
+
+    const Mat3D rot_mat = EulerAnglesToMatrix<double>(roll, pitch, hdg);
+    for (Vec3D& pt_uvz : road_obj_mesh.vertices)
+    {
+        pt_uvz = MatVecMultiplication(rot_mat, pt_uvz);
+        pt_uvz = add(pt_uvz, {this->s0, this->t0, this->z0});
+        pt_uvz = road_ptr->get_xyz(pt_uvz[0], pt_uvz[1], pt_uvz[2]);
     }
 
     return road_obj_mesh;

--- a/RoadObject.h
+++ b/RoadObject.h
@@ -24,11 +24,11 @@ struct RoadObjectRepeat
     double z_offset_end = 0;
 };
 
-struct RoadObjectCorner
+struct RoadObjectCornerLocal
 {
-    double s = 0;
-    double t = 0;
-    double dz = 0;
+    double u = 0;
+    double v = 0;
+    double z = 0;
     double height = 0;
 };
 
@@ -60,7 +60,8 @@ struct RoadObject
     double roll = 0;
 
     std::vector<RoadObjectRepeat> repeats;
-    std::vector<RoadObjectCorner> outline;
+
+    std::vector<RoadObjectCornerLocal> local_outline;
 
     std::weak_ptr<Road> road;
 };

--- a/RoadObject.h
+++ b/RoadObject.h
@@ -38,6 +38,9 @@ struct RoadObject
 
     Mesh3D get_mesh(double eps) const;
 
+    static Mesh3D get_cylinder(double eps, double radius, double height);
+    static Mesh3D get_box(double width, double length, double height);
+
     std::string type;
     std::string name;
     std::string id;

--- a/RoadObject.h
+++ b/RoadObject.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "Mesh.h"
+
+#include <memory>
+#include <vector>
+
+namespace odr
+{
+class Road;
+
+struct RoadObjectRepeat
+{
+    double s0 = 0;
+    double length = 0;
+    double distance = 0;
+    double t_start = 0;
+    double t_end = 0;
+    double width_start = 0;
+    double width_end = 0;
+    double height_start = 0;
+    double height_end = 0;
+    double z_offset_start = 0;
+    double z_offset_end = 0;
+};
+
+struct RoadObjectCorner
+{
+    double s = 0;
+    double t = 0;
+    double dz = 0;
+    double height = 0;
+};
+
+struct RoadObject
+{
+    RoadObject() = default;
+
+    Mesh3D get_mesh(double eps) const;
+
+    std::string type;
+    std::string name;
+    std::string id;
+    std::string orientation;
+
+    double s0 = 0;
+    double t0 = 0;
+    double z0 = 0;
+
+    double length = 0;
+    double valid_length = 0;
+    double width = 0;
+    double radius = 0;
+    double height = 0;
+    double hdg = 0;
+    double pitch = 0;
+    double roll = 0;
+
+    std::vector<RoadObjectRepeat> repeats;
+    std::vector<RoadObjectCorner> outline;
+
+    std::weak_ptr<Road> road;
+};
+} // namespace odr

--- a/Utils.hpp
+++ b/Utils.hpp
@@ -12,6 +12,12 @@
 #include <type_traits>
 #include <vector>
 
+#define CHECK(expr, msg)                                                                                                                             \
+    {                                                                                                                                                \
+        if (!(expr))                                                                                                                                 \
+            printf("[%s:%d %s] check failed: %s\n", __FILE_NAME__, __LINE__, __FUNCTION__, msg);                                                     \
+    }
+
 #define CHECK_AND_REPAIR(check_expr, msg, repair_expr)                                                                                               \
     {                                                                                                                                                \
         if (!(check_expr))                                                                                                                           \


### PR DESCRIPTION
Adding basic support for road::objects, including:
- object::repeat, with continuous features (if distance == 0)
- object::outline::cornerLocal

Not supported yet
- object::outline::cornerRoad
- object::object::material