### PR TITLE
Parse road link information

### DIFF
--- a/OpenDriveMap.cpp
+++ b/OpenDriveMap.cpp
@@ -64,9 +64,9 @@ OpenDriveMap::OpenDriveMap(const std::string& xodr_file, const OpenDriveMapConfi
             if (road_link_node)
             {
                 RoadLink& link = is_predecessor ? road->predecessor : road->successor;
-                link.elementId = road_link_node.child("elementId").text().as_string();
-                link.elementType = road_link_node.child("elementType").text().as_string();
-                link.contactPoint = road_link_node.child("contactPoint").text().as_string();
+                link.elementId = road_link_node.attribute("elementId").as_string();
+                link.elementType = road_link_node.attribute("elementType").as_string();
+                link.contactPoint = road_link_node.attribute("contactPoint").as_string();
                 link.xml_node = road_link_node;
             }
         }


### PR DESCRIPTION
Changed parsing of road link information to look for attributes instead of children.

I noticed that all road links were being parsed into empty objects (`{elementID = "", elementType = "", contactPoint = ""}`), and that the ASAM specification and the maps I was referencing have road link contents stored as attributes instead of children. This fix seemed to work.

Thanks a ton for providing and maintaining this library.