### PR TITLE
Add MSVC Compile changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,23 @@ project(libOpenDrive VERSION 0.1.0 DESCRIPTION ".xodr library")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+
 set(CMAKE_CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+
+
+if(MSVC)
+SET(CMAKE_CXX_FLAGS "/EHsc")
+else()
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(BUILD_SHARED_LIBS ON)
+endif()
 
 include_directories(include)
 include_directories(Thirdparty)
 
-add_library(OpenDrive SHARED
+add_library(OpenDrive
     src/Geometries/Arc.cpp
     src/Geometries/CubicSpline.cpp
     src/Geometries/Line.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,23 +8,20 @@ project(libOpenDrive VERSION 0.1.0 DESCRIPTION ".xodr library")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-
-
 if(MSVC)
 SET(CMAKE_CXX_FLAGS "/EHsc")
+SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
 else()
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(BUILD_SHARED_LIBS ON)
 endif()
 
 include_directories(include)
 include_directories(Thirdparty)
 
-add_library(OpenDrive
+add_library(OpenDrive SHARED
     src/Geometries/Arc.cpp
     src/Geometries/CubicSpline.cpp
     src/Geometries/Line.cpp

--- a/include/Lane.h
+++ b/include/Lane.h
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 namespace odr
 {

--- a/include/Lane.h
+++ b/include/Lane.h
@@ -10,7 +10,6 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 namespace odr
 {

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -1,10 +1,4 @@
 #pragma once
-<<<<<<< HEAD
-
-=======
-#include <algorithm>
-#include <array>
->>>>>>> upstream/master
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <array>

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <algorithm>
-#include <array>
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <array>
+#include <algorithm>
 #include <numeric>
 #include <type_traits>
 #include <vector>

--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #define _USE_MATH_DEFINES
-#include <cmath>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <numeric>
 #include <type_traits>
 #include <vector>

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <string>
 
 namespace odr
 {


### PR DESCRIPTION
Add compatibility with the MSVC compiler (tested on VS 2019).

The change of order of the includes is intented as MSVC seems to have some problems with the <cmath> include not being at the top.
Also changed the cmake build script to differentiate between MSVC and other compilers. The option `BUILD_SHARED_LIBS` is used to build the shared lib on linux.