### PR TITLE
Add <stdexcept> into utils.hpp

### DIFF
--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <stdexcept>
 
 #define CHECK(expr, msg)                                                                                                                             \
     {                                                                                                                                                \


### PR DESCRIPTION
seems like its still needed as you throw runtime_errors inside utils.hpp.

PR adds the include in the needed file