### PR TITLE
Bug fix where isnan <double> template specifier causes compilation errors

### DIFF
--- a/src/RefLine.cpp
+++ b/src/RefLine.cpp
@@ -49,7 +49,7 @@ double RefLine::get_geometry_s0(const double s) const
 
 const RoadGeometry* RefLine::get_geometry(const double s) const
 {
-    double geom_s0 = this->get_geometry_s0(s);
+    const double geom_s0 = this->get_geometry_s0(s);
     if (std::isnan(geom_s0))
         return nullptr;
     return this->s0_to_geometry.at(geom_s0).get();

--- a/src/RefLine.cpp
+++ b/src/RefLine.cpp
@@ -49,8 +49,8 @@ double RefLine::get_geometry_s0(const double s) const
 
 const RoadGeometry* RefLine::get_geometry(const double s) const
 {
-    const double geom_s0 = this->get_geometry_s0(s);
-    if (std::isnan<double>(geom_s0))
+    double geom_s0 = this->get_geometry_s0(s);
+    if (std::isnan(geom_s0))
         return nullptr;
     return this->s0_to_geometry.at(geom_s0).get();
 }

--- a/src/Road.cpp
+++ b/src/Road.cpp
@@ -139,7 +139,7 @@ Vec3D Road::get_surface_pt(double s, const double t, Vec3D* vn) const
     CHECK_AND_REPAIR(s <= this->length, "s > Road::length", s = this->length);
 
     const double lanesection_s0 = this->get_lanesection_s0(s);
-    if (std::isnan<double>(lanesection_s0))
+    if (std::isnan(lanesection_s0))
     {
         throw std::runtime_error(string_format("cannot get road surface pt, no lane section for s %.3f, road length: %.3f", s, this->length));
     }


### PR DESCRIPTION
Bug fix where isnan <double> template specifier causes compilation errors, fixed it by removing the template specifier.