### PR TITLE
fix: include missing <functional> header

### DIFF
--- a/include/Math.hpp
+++ b/include/Math.hpp
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <type_traits>
 #include <vector>
+#include <functional>
 
 namespace odr
 {


### PR DESCRIPTION
I was getting compilation error, due to the missing header which says

`error: ‘plus’ is not a member of ‘std’`
`error: ‘minus’ is not a member of ‘std’`

These function objects are defined in header \<functional\> since C++-14.
So I included this header.

This PR is also related with issue #50