### PR TITLE
Add support for signals and lane validity records

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(OpenDrive SHARED
     src/RoadMark.cpp
     src/RoadNetworkMesh.cpp
     src/RoadObject.cpp
+    src/Signal.cpp
     src/RoutingGraph.cpp
     thirdparty/pugixml/pugixml.cpp
 )

--- a/include/Junction.h
+++ b/include/Junction.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <map>
 #include <set>
+#include <cstdint>
 #include <string>
 
 namespace odr

--- a/include/LaneValidityRecord.h
+++ b/include/LaneValidityRecord.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "XmlNode.h"
+
+#include <climits>
+
+namespace odr
+{
+
+struct LaneValidityRecord : public XmlNode
+{
+    LaneValidityRecord(int from_lane, int to_lane) : from_lane(from_lane), to_lane(to_lane) {}
+
+    int from_lane = INT_MIN;
+    int to_lane = INT_MAX;
+};
+
+} // namespace odr

--- a/include/OpenDriveMap.h
+++ b/include/OpenDriveMap.h
@@ -19,6 +19,7 @@ public:
     OpenDriveMap(const std::string& xodr_file,
                  const bool         center_map = false,
                  const bool         with_road_objects = true,
+                 const bool         with_signals = true,
                  const bool         with_lateral_profile = true,
                  const bool         with_lane_height = true,
                  const bool         abs_z_for_for_local_road_obj_outline = false,

--- a/include/OpenDriveMap.h
+++ b/include/OpenDriveMap.h
@@ -19,11 +19,11 @@ public:
     OpenDriveMap(const std::string& xodr_file,
                  const bool         center_map = false,
                  const bool         with_road_objects = true,
-                 const bool         with_signals = true,
                  const bool         with_lateral_profile = true,
                  const bool         with_lane_height = true,
                  const bool         abs_z_for_for_local_road_obj_outline = false,
-                 const bool         fix_spiral_edge_cases = true);
+                 const bool         fix_spiral_edge_cases = true,
+                 const bool         with_signals = true);
 
     std::vector<Road>     get_roads() const;
     std::vector<Junction> get_junctions() const;

--- a/include/Road.h
+++ b/include/Road.h
@@ -5,6 +5,7 @@
 #include "Mesh.h"
 #include "RefLine.h"
 #include "RoadObject.h"
+#include "Signal.h"
 #include "XmlNode.h"
 
 #include <cstddef>
@@ -82,6 +83,7 @@ public:
 
     std::vector<LaneSection> get_lanesections() const;
     std::vector<RoadObject>  get_road_objects() const;
+    std::vector<Signal>      get_signals() const;
 
     double      get_lanesection_s0(const double s) const;
     LaneSection get_lanesection(const double s) const;
@@ -126,6 +128,7 @@ public:
     std::map<double, std::string>     s_to_type;
     std::map<double, SpeedRecord>     s_to_speed;
     std::map<std::string, RoadObject> id_to_object;
+    std::map<std::string, Signal>     id_to_signal;
 };
 
 } // namespace odr

--- a/include/RoadObject.h
+++ b/include/RoadObject.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "LaneValidityRecord.h"
 #include "Math.hpp"
 #include "Mesh.h"
 #include "XmlNode.h"
@@ -111,8 +112,9 @@ struct RoadObject : public XmlNode
     double roll = 0;
     bool   is_dynamic = false;
 
-    std::vector<RoadObjectRepeat>  repeats;
-    std::vector<RoadObjectOutline> outlines;
+    std::vector<RoadObjectRepeat>   repeats;
+    std::vector<RoadObjectOutline>  outlines;
+    std::vector<LaneValidityRecord> lane_validities;
 };
 
 } // namespace odr

--- a/include/Signal.h
+++ b/include/Signal.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "LaneValidityRecord.h"
+#include "XmlNode.h"
+
+#include <string>
+#include <vector>
+
+namespace odr
+{
+
+struct Signal : public XmlNode
+{
+    Signal(std::string road_id,
+           std::string id,
+           std::string name,
+           double      s0,
+           double      t0,
+           bool        is_dynamic,
+           double      zOffset,
+           double      value,
+           double      height,
+           double      width,
+           double      hOffset,
+           double      pitch,
+           double      roll,
+           std::string orientation,
+           std::string country,
+           std::string type,
+           std::string subtype,
+           std::string unit,
+           std::string text);
+
+    std::string road_id = "";
+    std::string id = "";
+    std::string name = "";
+    double      s0 = 0;
+    double      t0 = 0;
+    bool        is_dynamic = false;
+    double      zOffset = 0;
+    double      value = 0;
+    double      height = 0;
+    double      width = 0;
+    double      hOffset = 0;
+    double      pitch = 0;
+    double      roll = 0;
+    std::string orientation = "";
+    std::string country = "";
+    std::string type = "";
+    std::string subtype = "";
+    std::string unit = "";
+    std::string text = "";
+
+    std::vector<LaneValidityRecord> lane_validities;
+};
+
+} // namespace odr

--- a/src/OpenDriveMap.cpp
+++ b/src/OpenDriveMap.cpp
@@ -57,11 +57,11 @@ std::vector<LaneValidityRecord> extract_lane_validity_records(const pugi::xml_no
 OpenDriveMap::OpenDriveMap(const std::string& xodr_file,
                            const bool         center_map,
                            const bool         with_road_objects,
-                           const bool         with_signals,
                            const bool         with_lateral_profile,
                            const bool         with_lane_height,
                            const bool         abs_z_for_for_local_road_obj_outline,
-                           const bool         fix_spiral_edge_cases) :
+                           const bool         fix_spiral_edge_cases,
+                           const bool         with_signals) :
     xodr_file(xodr_file)
 {
     pugi::xml_parse_result result = this->xml_doc.load_file(xodr_file.c_str());
@@ -649,12 +649,12 @@ OpenDriveMap::OpenDriveMap(const std::string& xodr_file,
                                                      signal_node.attribute("hOffset").as_double(0),
                                                      signal_node.attribute("pitch").as_double(0),
                                                      signal_node.attribute("roll").as_double(0),
-                                                     signal_node.attribute("orientation").as_string(""),
+                                                     signal_node.attribute("orientation").as_string("none"),
                                                      signal_node.attribute("country").as_string(""),
-                                                     signal_node.attribute("type").as_string(""),
-                                                     signal_node.attribute("subtype").as_string(""),
+                                                     signal_node.attribute("type").as_string("none"),
+                                                     signal_node.attribute("subtype").as_string("none"),
                                                      signal_node.attribute("unit").as_string(""),
-                                                     signal_node.attribute("text").as_string(""))})
+                                                     signal_node.attribute("text").as_string("none"))})
                                      .first->second;
                 signal.xml_node = signal_node;
 

--- a/src/Road.cpp
+++ b/src/Road.cpp
@@ -53,6 +53,8 @@ std::vector<LaneSection> Road::get_lanesections() const { return get_map_values(
 
 std::vector<RoadObject> Road::get_road_objects() const { return get_map_values(this->id_to_object); }
 
+std::vector<Signal> Road::get_signals() const { return get_map_values(this->id_to_signal); }
+
 Road::Road(std::string id, double length, std::string junction, std::string name) :
     length(length), id(id), junction(junction), name(name), ref_line(id, length)
 {

--- a/src/Signal.cpp
+++ b/src/Signal.cpp
@@ -1,0 +1,30 @@
+#include "Signal.h"
+
+namespace odr
+{
+Signal::Signal(std::string road_id,
+               std::string id,
+               std::string name,
+               double      s0,
+               double      t0,
+               bool        is_dynamic,
+               double      zOffset,
+               double      value,
+               double      height,
+               double      width,
+               double      hOffset,
+               double      pitch,
+               double      roll,
+               std::string orientation,
+               std::string country,
+               std::string type,
+               std::string subtype,
+               std::string unit,
+               std::string text) :
+    road_id(std::move(road_id)),
+    id(std::move(id)), name(std::move(name)), s0(s0), t0(t0), is_dynamic(is_dynamic), zOffset(zOffset), value(value), height(height), width(width),
+    hOffset(hOffset), pitch(pitch), roll(roll), orientation(std::move(orientation)), country(std::move(country)), type(std::move(type)),
+    subtype(std::move(subtype)), unit(std::move(unit)), text(std::move(text))
+{
+}
+} // namespace odr

--- a/src/Signal.cpp
+++ b/src/Signal.cpp
@@ -21,10 +21,9 @@ Signal::Signal(std::string road_id,
                std::string subtype,
                std::string unit,
                std::string text) :
-    road_id(std::move(road_id)),
-    id(std::move(id)), name(std::move(name)), s0(s0), t0(t0), is_dynamic(is_dynamic), zOffset(zOffset), value(value), height(height), width(width),
-    hOffset(hOffset), pitch(pitch), roll(roll), orientation(std::move(orientation)), country(std::move(country)), type(std::move(type)),
-    subtype(std::move(subtype)), unit(std::move(unit)), text(std::move(text))
+    road_id(road_id),
+    id(id), name(name), s0(s0), t0(t0), is_dynamic(is_dynamic), zOffset(zOffset), value(value), height(height), width(width), hOffset(hOffset),
+    pitch(pitch), roll(roll), orientation(orientation), country(country), type(type), subtype(subtype), unit(unit), text(text)
 {
 }
 } // namespace odr


### PR DESCRIPTION
This PR makes the following changes
* Add support for parsing signals (related to issue #21) along with lane validity records
* Add support for parsing lane validity records of road objects

I tested it on [this map with signals](https://github.com/pyoscx/scenariogeneration/blob/main/examples/xodr/junction_with_signals.py) and [this map with objects](https://github.com/pyoscx/scenariogeneration/blob/main/examples/xodr/simple_road_with_objects.py). The maps were slightly modified, e.g.,
```
<object id="0" s="0" t="6.8" subtype="None" dynamic="no" zOffset="0.4" pitch="0" roll="0" height="0.3" name="guardRail" type="barrier" orientation="none" hdg="3.141592653589793">
    <repeat length="1000" distance="0" s="0" tStart="6.8" tEnd="6.8" heightStart="0.3" heightEnd="0.3" zOffsetStart="0.4" zOffsetEnd="0.4"/>
     <validity fromLane="-1" toLane="2"/>
</object>
```
or
```
<signal id="0" s="98.0" t="-4" subtype="1" dynamic="no" zOffset="1.5" pitch="0" roll="0" type="R1" orientation="+" country="USA" hOffset="0">
    <validity fromLane="-2"/>
</signal>
```

Would love to have this feature merged. Looking forward to suggestions/comments.

PS: Thanks for making this amazing tool @grepthat 